### PR TITLE
Remove object citation feature

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,8 +1,5 @@
 .__settings__ <- list(
-  sep = " ",
   bib = 1L,
-  obj_first = TRUE,
-  obj = "the ':obj' :type from",
   pkg = "the ':pkg' package version :ver [:ref]",
   pkg_list = "':pkg' v. :ver [:ref]",
   r = "R version :ver [:ref]"

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -47,12 +47,8 @@ is_named <- function(x) {
   TRUE
 }
 
-is_base <- function(x) {
-  x$pkg == "base"
-}
-
 is_r <- function(x) {
-  x$pkg == "R"
+  x %in% c("R", "base")
 }
 
 is_manual <- function(x) {
@@ -191,28 +187,10 @@ check_bib <- function(x, arg = caller_arg(x)) {
   check_type(x, is_bib, "a `.bib` file", arg)
 }
 
-check_items <- function(x) {
-  if (is_r(x) || is_base(x)) {
-    return(invisible())
-  }
-  check_pkg(x$pkg)
-  if (!is.null(x$obj) && getOption("pakret.check_obj", FALSE)) {
-    check_obj(x$pkg, x$obj)
-  }
-}
-
 check_pkg <- function(pkg) {
   path <- system.file(package = pkg)
   if (!is_empty(path)) {
     return(invisible())
   }
   abort("Package `%s` doesn't exist or isn't installed.", pkg)
-}
-
-check_obj <- function(pkg, obj) {
-  obj_exists <- exists(obj, where = asNamespace(pkg))
-  if (obj_exists) {
-    return(invisible())
-  }
-  abort("`%s` isn't exported from the package `%s`.", obj, pkg)
 }

--- a/R/pkrt-list.R
+++ b/R/pkrt-list.R
@@ -40,7 +40,7 @@ itemize_citations <- function(pkgs) {
   names(pkgs) <- pkgs
   citations <- lapply(pkgs, function(pkg) {
     check_pkg(pkg)
-    citation <- cite(pkg)
+    citation <- cite(pkg, template = "pkg_list")
     attributes(citation) <- pkg_details(pkg)
     citation
   })

--- a/R/pkrt-set.R
+++ b/R/pkrt-set.R
@@ -15,11 +15,11 @@
 #' Use `NULL` to reset a parameter to its default value.
 #' @examples
 #' pkrt_set(pkg = ":pkg (v. :ver) :ref")
-#' pkrt(pakret)
+#' pkrt("pakret")
 #'
 #' # `NULL` resets parameters to their default value
 #' pkrt_set(pkg = NULL)
-#' pkrt(pakret)
+#' pkrt("pakret")
 #' @export
 pkrt_set <- function(...) {
   items <- list(...)
@@ -62,11 +62,6 @@ set_option.default <- function(x) {
   abort("`%s` isn't a valid setting.", names(x))
 }
 
-set_option.sep <- function(x) {
-  check_string(x, arg = names(x))
-  update(x)
-}
-
 set_option.template <- function(x) {
   check_template(x, arg = names(x))
   update(x)
@@ -82,11 +77,6 @@ set_option.bib <- function(x) {
   }
   check_bib_target(x)
   set(bib = x, file = bib_fetch())
-}
-
-set_option.obj_first <- function(x) {
-  check_bool(x, arg = names(x))
-  update(x)
 }
 
 # doc ----
@@ -111,24 +101,12 @@ make_pkrt_set_details <- function() {
   paste(out, collapse = "\n\n")
 }
 
-dedent <- function(x) {
-  indentation <- sub("(?s)\\S*\\R(\\s*).+", "\\1", x, perl = TRUE)
-  x <- gsub(paste0("(?m)^", indentation), "", x, perl = TRUE)
-  trimws(x)
-}
-
 details <- list(
-  obj = "Template used to cite a particular object from a package.",
-  pkg = "Template used to cite a package.",
-  pkg_list = "Template used in `pkrt_list()`.",
-  r = "Template used to cite R.",
   bib = list(
     "Name or index of the `.bib` file to save references to.",
     type = "character|numeric"
   ),
-  obj_first = "Should `obj` and `pkg` be reversed?",
-  sep = dedent("
-    Separator used to separate `obj` and `pkg`. This parameter is only useful
-      for people writing in languages that don't separate words with a space.
-  ")
+  pkg = "Template used to cite a package.",
+  pkg_list = "Template used in `pkrt_list()`.",
+  r = "Template used to cite R."
 )

--- a/R/pkrt.R
+++ b/R/pkrt.R
@@ -1,23 +1,17 @@
-#' @title Cite R, an R package or object
-#' @description Creates a preformatted citation of an R package or object. This
+#' @title Cite R or an R package
+#' @description Creates a preformatted citation of R or an R package. This
 #'   function should normally only be used in an R Markdown or Quarto document,
 #'   in which case `pkrt()` automatically references the cited package in the
 #'   first (by default) `.bib` file specified in the YAML header if no
 #'   references of the package already exist.
-#' @param expr A string or unquoted expression of the package or object to cite.
-#'   When citing an object, the expression must be in the form `pkg::object`.
-#'
-#'   Use `pkrt(R)` to cite R.
-#' @param object_type A string that describes the type of the object to cite.
+#' @param x A string of the package to cite. Use `pkrt("R")` to cite R.
 #' @returns A character string.
 #' @examples
-#' pkrt(pakret)
-#'
-#' pkrt(pakret::pkrt)
+#' pkrt("pakret")
 #' @export
-pkrt <- function(expr, object_type = "function") {
-  items <- parse_expr(substitute(expr))
-  check_items(items)
-  check_string(object_type)
-  cite(items, type = object_type)
+pkrt <- function(x) {
+  check_character(x)
+  pkg <- as_pkg(x)
+  check_pkg(pkg)
+  cite(pkg)
 }

--- a/R/utils-local.R
+++ b/R/utils-local.R
@@ -1,3 +1,9 @@
+dedent <- function(x) {
+  indentation <- sub("(?s)\\S*\\R(\\s*).+", "\\1", x, perl = TRUE)
+  x <- gsub(paste0("(?m)^", indentation), "", x, perl = TRUE)
+  trimws(x)
+}
+
 render <- function(...) {
   rmarkdown::render(..., output_format = "md_document", quiet = TRUE)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ pak::pak("arnaudgallou/pakret")
 Simply use `pkrt()` whenever you want to cite an R package or object in your document:
 
 ````{r, include = FALSE}
-template <- pakret:::dedent("
+template <- pakret:::dedent('
   ---
   bibliography: %s
   ---
@@ -60,12 +60,10 @@ template <- pakret:::dedent("
   library(pakret)
   ```
   %s
-  Maps were created using `r pkrt(foo)`.
-
-  We used `r pkrt(bar::blah)` to compute X.
+  We used `r pkrt("foo")` to analyse the data.
 
   ## References
-")
+')
 ````
 
 ```{r, echo = FALSE, class.output = "default"}
@@ -98,7 +96,7 @@ template <- pakret:::dedent('
   pkrt_set(pkg = "the R package :pkg (v. :ver; :ref)")
   ```
   %s
-  We used `r pkrt(foo)` to create the maps.
+  We used `r pkrt("foo")` to analyse the data.
 
   ## References
 ')
@@ -131,7 +129,7 @@ template <- pakret:::dedent('
   library(pakret)
   ```
   %s
-  We used the following packages: `r pkrt_list("foo", "bar")`.
+  We analyse the data using the following packages: `r pkrt_list("foo", "bar")`.
 
   ## References
 ')

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ your document:
     library(pakret)
     ```
 
-    Maps were created using `r pkrt(foo)`.
-
-    We used `r pkrt(bar::blah)` to compute X.
+    We used `r pkrt("foo")` to analyse the data.
 
     ## References
 
@@ -49,18 +47,13 @@ pakret handles everything for you.
 
 Here’s the markdown output produced by the document above:
 
-    Maps were created using the ‘foo’ package version 1.0.0 (Fastandfurius,
-    Clausus, and Lastopus 2020).
-
-    We used the ‘blah’ function from the ‘bar’ package version 0.2.0
-    (Itisalapsus 2024) to compute X.
+    We used the ‘foo’ package version 1.0.0 (Fastandfurius, Clausus, and
+    Lastopus 2020) to analyse the data.
 
     ## References
 
     Fastandfurius, Caius, Numerius Clausus, and Marcus Lastopus. 2020. *Foo:
     Alea Jacta Est*.
-
-    Itisalapsus, Julius. 2024. *Bar: Tempus Edax Rerum*.
 
 Unhappy with the default templates? pakret lets you define your own:
 
@@ -75,14 +68,14 @@ Unhappy with the default templates? pakret lets you define your own:
     pkrt_set(pkg = "the R package :pkg (v. :ver; :ref)")
     ```
 
-    We used `r pkrt(foo)` to create the maps.
+    We used `r pkrt("foo")` to analyse the data.
 
     ## References
 
 Which gives:
 
     We used the R package foo (v. 1.0.0; Fastandfurius, Clausus, and
-    Lastopus (2020)) to create the maps.
+    Lastopus (2020)) to analyse the data.
 
     ## References
 
@@ -101,14 +94,15 @@ It’s also possible to cite a collection of packages with `pkrt_list()`:
     library(pakret)
     ```
 
-    We used the following packages: `r pkrt_list("foo", "bar")`.
+    We analyse the data using the following packages: `r pkrt_list("foo", "bar")`.
 
     ## References
 
 Here’s the result:
 
-    We used the following packages: ‘foo’ v. 1.0.0 (Fastandfurius, Clausus,
-    and Lastopus 2020), ‘bar’ v. 0.2.0 (Itisalapsus 2024).
+    We analyse the data using the following packages: ‘foo’ v. 1.0.0
+    (Fastandfurius, Clausus, and Lastopus 2020), ‘bar’ v. 0.2.0 (Itisalapsus
+    2024).
 
     ## References
 

--- a/man/pkrt.Rd
+++ b/man/pkrt.Rd
@@ -2,30 +2,23 @@
 % Please edit documentation in R/pkrt.R
 \name{pkrt}
 \alias{pkrt}
-\title{Cite R, an R package or object}
+\title{Cite R or an R package}
 \usage{
-pkrt(expr, object_type = "function")
+pkrt(x)
 }
 \arguments{
-\item{expr}{A string or unquoted expression of the package or object to cite.
-When citing an object, the expression must be in the form \code{pkg::object}.
-
-Use \code{pkrt(R)} to cite R.}
-
-\item{object_type}{A string that describes the type of the object to cite.}
+\item{x}{A string of the package to cite. Use \code{pkrt("R")} to cite R.}
 }
 \value{
 A character string.
 }
 \description{
-Creates a preformatted citation of an R package or object. This
+Creates a preformatted citation of R or an R package. This
 function should normally only be used in an R Markdown or Quarto document,
 in which case \code{pkrt()} automatically references the cited package in the
 first (by default) \code{.bib} file specified in the YAML header if no
 references of the package already exist.
 }
 \examples{
-pkrt(pakret)
-
-pkrt(pakret::pkrt)
+pkrt("pakret")
 }

--- a/man/pkrt_set.Rd
+++ b/man/pkrt_set.Rd
@@ -18,9 +18,9 @@ references to.
 \details{
 Valid parameters are:
 \itemize{
-\item \strong{obj}\if{html}{\out{<br>}}
-\verb{<character> = "the ':obj' :type from"}\if{html}{\out{<br>}}
-Template used to cite a particular object from a package.
+\item \strong{bib}\if{html}{\out{<br>}}
+\verb{<character|numeric> = 1L}\if{html}{\out{<br>}}
+Name or index of the \code{.bib} file to save references to.
 \item \strong{pkg}\if{html}{\out{<br>}}
 \verb{<character> = "the ':pkg' package version :ver [:ref]"}\if{html}{\out{<br>}}
 Template used to cite a package.
@@ -30,16 +30,6 @@ Template used in \code{pkrt_list()}.
 \item \strong{r}\if{html}{\out{<br>}}
 \verb{<character> = "R version :ver [:ref]"}\if{html}{\out{<br>}}
 Template used to cite R.
-\item \strong{bib}\if{html}{\out{<br>}}
-\verb{<character|numeric> = 1L}\if{html}{\out{<br>}}
-Name or index of the \code{.bib} file to save references to.
-\item \strong{obj_first}\if{html}{\out{<br>}}
-\verb{<logical> = TRUE}\if{html}{\out{<br>}}
-Should \code{obj} and \code{pkg} be reversed?
-\item \strong{sep}\if{html}{\out{<br>}}
-\verb{<character> = " "}\if{html}{\out{<br>}}
-Separator used to separate \code{obj} and \code{pkg}. This parameter is only useful
-for people writing in languages that don't separate words with a space.
 }
 
 New settings only apply to citations that come after \code{pkrt_set()}. This means
@@ -50,9 +40,9 @@ Use \code{NULL} to reset a parameter to its default value.
 }
 \examples{
 pkrt_set(pkg = ":pkg (v. :ver) :ref")
-pkrt(pakret)
+pkrt("pakret")
 
 # `NULL` resets parameters to their default value
 pkrt_set(pkg = NULL)
-pkrt(pakret)
+pkrt("pakret")
 }

--- a/tests/testthat/_snaps/pkrt-set.md
+++ b/tests/testthat/_snaps/pkrt-set.md
@@ -17,14 +17,6 @@
     Output
       <simpleError: `foo` isn't a valid setting.>
     Code
-      (expect_error(pkrt_set(sep = 1)))
-    Output
-      <simpleError: `sep` must be a string.>
-    Code
-      (expect_error(pkrt_set(obj_first = 1)))
-    Output
-      <simpleError: `obj_first` must be `TRUE` or `FALSE`.>
-    Code
       (expect_error(pkrt_set(pkg = 1)))
     Output
       <simpleError: `pkg` must be a string.>

--- a/tests/testthat/_snaps/pkrt.md
+++ b/tests/testthat/_snaps/pkrt.md
@@ -52,18 +52,11 @@
 # pkrt() gives meaningful error messages
 
     Code
-      (expect_error(pkrt(a)))
+      (expect_error(pkrt(1)))
+    Output
+      <simpleError: `x` must be a character vector.>
+    Code
+      (expect_error(pkrt("a")))
     Output
       <simpleError: Package `a` doesn't exist or isn't installed.>
-    Code
-      (expect_error(pkrt(pakret, object_type = 1)))
-    Output
-      <simpleError: `object_type` must be a string.>
-    Code
-      (expect_error({
-        withr::local_options(pakret.check_obj = TRUE)
-        pkrt(pakret::foo)
-      }))
-    Output
-      <simpleError: `foo` isn't exported from the package `pakret`.>
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -10,7 +10,7 @@ make_template <- function(lines = "", meta = "bibliography: %s") {
 }
 
 extract_pkgs <- function(x) {
-  unique(extract(x, "(?<=pkrt\\()[a-z]+"))
+  unique(extract(x, "pkrt\\([\"']\\K[a-z]+"))
 }
 
 to_load <- function(x) {

--- a/tests/testthat/test-pkrt-set.R
+++ b/tests/testthat/test-pkrt-set.R
@@ -1,23 +1,14 @@
 test_that("custom templates work", {
   load_foo()
-  local_settings(obj = ":type :obj", pkg = ":ref :ver :pkg")
-  expect_equal(pkrt(foo::bar), "function bar @foo 1.0.0 foo")
-})
-
-test_that("custom settings work", {
-  load_foo()
-  local_settings(obj_first = FALSE, sep = " | ")
-  expect_equal(
-    pkrt(foo::bar),
-    "the 'foo' package version 1.0.0 [@foo] | the 'bar' function from"
-  )
+  local_settings(pkg = ":ref :ver :pkg")
+  expect_equal(pkrt("foo"), "@foo 1.0.0 foo")
 })
 
 test_that("`NULL` resets settings to their default value", {
   load_foo()
   pkrt_set(pkg = ":ref :ver :pkg")
   pkrt_set(pkg = NULL)
-  expect_equal(pkrt(foo), "the 'foo' package version 1.0.0 [@foo]")
+  expect_equal(pkrt("foo"), "the 'foo' package version 1.0.0 [@foo]")
 })
 
 test_that("writing bib entries in the desired file works", {
@@ -25,7 +16,7 @@ test_that("writing bib entries in the desired file works", {
   dir <- local_files(n_bib = 2L, make_template(lines = dedent("
     ```{r}
     pkrt_set(bib = 2L)
-    pkrt(foo)
+    pkrt('foo')
     ```
   ")))
 
@@ -51,12 +42,6 @@ test_that("pkrt_set() gives meaningful error messages", {
     ))
     (expect_error(
       pkrt_set(foo = 1)
-    ))
-    (expect_error(
-      pkrt_set(sep = 1)
-    ))
-    (expect_error(
-      pkrt_set(obj_first = 1)
     ))
     (expect_error(
       pkrt_set(pkg = 1)

--- a/tests/testthat/test-pkrt.R
+++ b/tests/testthat/test-pkrt.R
@@ -1,19 +1,19 @@
 test_that("pkrt() cites and references packages", {
   skip_on_os("windows")
-  dir <- local_files(make_template(lines = "`r pkrt(foo)`"))
+  dir <- local_files(make_template(lines = "`r pkrt('foo')`"))
   res <- read_local_file(dir)
   expect_snapshot(cat(res))
 })
 
 test_that("bib entries are properly appended to bib files", {
   skip_on_os("windows")
-  template <- make_template(lines = "`r pkrt(foo)` `r pkrt(bar)`")
+  template <- make_template(lines = "`r pkrt('foo')` `r pkrt('bar')`")
   dir <- local_files(template)
   res <- read_local_file(dir, target = "bib")
   expect_snapshot(cat(res))
 
   load_bar()
-  template <- make_template(lines = "`r pkrt(foo)`")
+  template <- make_template(lines = "`r pkrt('foo')`")
   dir <- local_files(template, bib_lines = get_citation("bar"))
   res <- read_local_file(dir, target = "bib")
   expect_snapshot(cat(res))
@@ -21,18 +21,18 @@ test_that("bib entries are properly appended to bib files", {
 
 test_that("multi-bib entries are properly handled", {
   skip_on_os("windows")
-  template <- dedent('
+  template <- dedent("
     ---
     bibliography: %s
     ---
     ```{r}
     library(pakret)
-    pakret:::load_foo(bib_entries = c("Article", "Manual"))
-    pakret:::load_bar(bib_entries = c("Book", "Article"))
+    pakret:::load_foo(bib_entries = c('Article', 'Manual'))
+    pakret:::load_bar(bib_entries = c('Book', 'Article'))
     ```
-    `r pkrt(foo)`
-    `r pkrt(bar)`
-  ')
+    `r pkrt('foo')`
+    `r pkrt('bar')`
+  ")
   dir <- local_files(template)
   res <- read_local_file(dir, target = "bib")
 
@@ -42,7 +42,7 @@ test_that("multi-bib entries are properly handled", {
 
 test_that("citing the same package again doesn't add a new bib entry", {
   skip_on_os("windows")
-  dir <- local_files(make_template(lines = strrep("`r pkrt(foo)`", 2L)))
+  dir <- local_files(make_template(lines = strrep("`r pkrt('foo')`", 2L)))
   res <- read_local_file(dir, target = "bib")
   expect_length(extract(res, "(?m)^@"), 1L)
 })
@@ -56,22 +56,10 @@ test_that("citing no packages doesn't modify bib files", {
   expect_equal(res, paste0(citation, eol()))
 })
 
-test_that("objects are properly cited", {
-  load_foo()
-  expect_equal(
-    pkrt(foo::bar),
-    "the 'bar' function from the 'foo' package version 1.0.0 [@foo]"
-  )
-  expect_equal(
-    pkrt(foo::bar, "data set"),
-    "the 'bar' data set from the 'foo' package version 1.0.0 [@foo]"
-  )
-})
-
 test_that("pkrt() cites R", {
   pattern <- "R version [\\d.]+ \\[@base\\]"
-  expect_match(pkrt(R), regexp = pattern, perl = TRUE)
-  expect_match(pkrt(base), regexp = pattern, perl = TRUE)
+  expect_match(pkrt("R"), regexp = pattern, perl = TRUE)
+  expect_match(pkrt("base"), regexp = pattern, perl = TRUE)
 })
 
 # errors
@@ -79,14 +67,10 @@ test_that("pkrt() cites R", {
 test_that("pkrt() gives meaningful error messages", {
   expect_snapshot({
     (expect_error(
-      pkrt(a)
+      pkrt(1)
     ))
     (expect_error(
-      pkrt(pakret, object_type = 1)
+      pkrt("a")
     ))
-    (expect_error({
-      withr::local_options(pakret.check_obj = TRUE)
-      pkrt(pakret::foo)
-    }))
   })
 })


### PR DESCRIPTION
This feature would be useful in too few occasions and with marginal advantages compared to writing the cited object manually to be worth keeping.