### PR TITLE
Remove class `list` from `pkrt_list()` output

### DIFF
--- a/R/pkrt-list.R
+++ b/R/pkrt-list.R
@@ -47,7 +47,7 @@ itemize_citations <- function(pkgs) {
 }
 
 as_pkrt_list <- function(x) {
-  structure(x, class = c("pkrt_list", "list"))
+  structure(x, class = "pkrt_list")
 }
 
 #' @export

--- a/tests/testthat/_snaps/pkrt-list.md
+++ b/tests/testthat/_snaps/pkrt-list.md
@@ -24,7 +24,7 @@
         ..- attr(*, "pkg")= chr "bar"
         ..- attr(*, "ver")= chr "0.2.0"
         ..- attr(*, "ref")= chr "@bar"
-       - attr(*, "class")= chr [1:2] "pkrt_list" "list"
+       - attr(*, "class")= chr "pkrt_list"
 
 # pkrt_list() gives meaningful error messages
 


### PR DESCRIPTION
This is for compatibility with `tibble::as_tibble()` to dispatch the appropriate method.