### PR TITLE
Use knitr to get the directory of the rendered file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,13 +15,13 @@ BugReports: https://github.com/arnaudgallou/pakret/issues
 Depends:
     R (>= 3.6.0)
 Imports:
+    knitr,
     readr (>= 1.0.0),
     rmarkdown,
     utils,
     withr (>= 2.5.0)
 Suggests:
     callr (>= 3.7.5),
-    knitr,
     pkgload,
     testthat (>= 3.0.0),
     usethis

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -31,10 +31,6 @@ is_blank <- function(x) {
   grepl("^\\s*$", x)
 }
 
-is_partial_path <- function(x) {
-  !grepl("^(?:~|\\.\\.)\\/", x) && grepl("/", x, fixed = TRUE)
-}
-
 is_template <- function(x) {
   x %in% template_keys
 }

--- a/R/pakret.R
+++ b/R/pakret.R
@@ -50,12 +50,8 @@ bib_fetch <- function() {
 }
 
 get_path <- function(x) {
-  if (!is_partial_path(x)) {
-    return(x)
-  }
-  path_ls <- dir(pattern = basename(x), recursive = TRUE)
-  x <- path_ls[grepl(x, path_ls, fixed = TRUE)]
-  if (is_empty(x)) path_ls else x
+  dir <- knitr::opts_knit$get("output.dir")
+  file.path(dir, x)
 }
 
 extract_refs <- function() {

--- a/R/utils-local.R
+++ b/R/utils-local.R
@@ -13,7 +13,8 @@ local_rmd <- function(lines = "", ...) {
 }
 
 local_bib <- function(lines, ...) {
-  withr::local_tempfile(lines = lines, fileext = ".bib", ...)
+  dir <- withr::local_tempfile(lines = lines, fileext = ".bib", ...)
+  basename(dir)
 }
 
 local_bibs <- function(lines, n, ...) {


### PR DESCRIPTION
This allows pakret to work with `.bib` files located in nested folders.