### PR TITLE
Reset bib metadata when setting a new `.bib` file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pakret (development version)
 
+* Fixed an issue with `pkrt_set(bib =)` that may lead to the replication or deletion of some bib entries in the newly defined `.bib` file in some edge cases (#22).
+
 # pakret 0.2.1
 
 * pakret now can cite references that have a pre-written key (#18).

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -23,6 +23,10 @@ is_bib <- function(x) {
   tolower(substr(x, n - 3L, n)) == ".bib"
 }
 
+is_updating_bib <- function(x) {
+  is_rendering() && names(x) == "bib"
+}
+
 is_unit_set <- function(x) {
   length(x) == 1L
 }

--- a/R/pakret.R
+++ b/R/pakret.R
@@ -37,6 +37,10 @@ add_class <- function(x, cls) {
 
 bib_init <- function() {
   check_bibliography()
+  bib_set()
+}
+
+bib_set <- function() {
   set(
     refs = list(),
     append = FALSE,

--- a/R/pkrt-set.R
+++ b/R/pkrt-set.R
@@ -54,6 +54,9 @@ reset <- function(x) {
 
 update <- function(x) {
   do.call(set, as.list(x))
+  if (is_updating_bib(x)) {
+    bib_set()
+  }
 }
 
 set_option <- function(x) {
@@ -74,7 +77,7 @@ set_option.bib <- function(x) {
     x[] <- bib_name(x)
   }
   check_bib_target(x)
-  set(bib = x, file = bib_fetch())
+  update(x)
 }
 
 # doc ----

--- a/tests/testthat/test-pkrt-set.R
+++ b/tests/testthat/test-pkrt-set.R
@@ -13,18 +13,26 @@ test_that("`NULL` resets settings to their default value", {
 
 test_that("writing bib entries in the desired file works", {
   skip_on_os("windows")
-  dir <- local_files(bib = local_set(n = 2L), make_template(lines = dedent("
+  template <- make_template(lines = dedent("
     ```{r}
     pkrt_set(bib = 2L)
     pkrt('foo')
     ```
-  ")))
+  "))
+  load_bar()
+  dir <- local_files(template, bib = local_set(
+    # the pre-written ref is to ensure that pkrt_set() resets bib metadata (#22)
+    lines = get_reference("bar"),
+    n = 2L
+  ))
 
   res <- read_local_file(dir, target = "file_1.bib")
   expect_match(res, "^\\R$", perl = TRUE)
 
   res <- read_local_file(dir, target = "file_2.bib")
-  expect_match(res, "^@Manual\\{foo,")
+  expect_match(res, "@Manual\\{bar,")
+  expect_match(res, "@Manual\\{foo,")
+  expect_length(extract(res, "(?m)^@"), 2L)
 })
 
 # errors


### PR DESCRIPTION
Fixes #22 